### PR TITLE
Listing link to dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # ClientDownloader
 Program to download base files for World of Warcraft 4.3.4.15595 (e.g Wow.exe) from Blizzard servers
+
+# Dependience 
+ASP.NET Core 3.1 Runtime (v3.1.13)
+https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-aspnetcore-3.1.13-windows-hosting-bundle-installer


### PR DESCRIPTION
Adding Link to ASP.NET Core 3.1 Runtime (v3.1.13) as it is required to run the application. Had to wipe and reinstall my computer and didn't have this dependency so it wouldn't install until I grabbed it.